### PR TITLE
Dockerfile: Update python to 3.12.5-alpine

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-alpine
+FROM python:3.12.5-alpine
 WORKDIR /code
 ENV FLASK_APP app.py
 ENV FLASK_RUN_HOST 0.0.0.0


### PR DESCRIPTION

Image **python** updated from 3.7-alpine to 3.12.5-alpine

**Image:** [python](https://hub.docker.com/r/library/python/)  
**Version:** 3.7-alpine &rarr; 3.12.5-alpine  
**Dockerfile:** Dockerfile  
**Related PR:** https://github.com/mankinimbom/Kubernetes-1/pull/2

If you need help or something went wrong, please comment here while mentioning me (@DockerUpBot) or use the [support formular](https://dockerup.net/support?repo=4b85445c-4444-4a9d-811c-9ccfba55c0a0).

<hr>
<p align="center">
  <a href="https://dockerup.net"><img align="center" src="https://dockerup.net/img/logo.svg" alt="Docker Up" width="200px"></a>
<br>
Automated <b>Dockerfile</b> updates
</p>
	